### PR TITLE
Fix page height

### DIFF
--- a/_includes/css/screen.css
+++ b/_includes/css/screen.css
@@ -3,10 +3,6 @@
   padding: 0;
 }
 
-html, body {
-  height: 100%;
-}
-
 body {
   font-size: 16px;
   background-color: #faddc6;


### PR DESCRIPTION
Previously the page would be viewport size + 7px because of the border
at the top - remove height: 100% so that it will equal viewport size,
and there will be no scrollbar if the content fits on the page